### PR TITLE
Update LUD-04; no HTTP GET for LNURL-auth when tag has login value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.1] - 2022.10.04
+- Extended and reorganized LNURL testcases
+- Updated README with full, partial or no support for LUDs
+- Fix: replaced keyauth with https for keyauth-scheme input
+
 ## [0.2.0] - 2022.10.01
 - Added LUD-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## [0.2.0] - 2022.10.01
+- Added LUD-05
+
 ## [0.1.0] - 2021.11.17
 - Migrated to null safety
 
 ## [0.0.1] - Initial release
-* First release
+- First release

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Andrew Coutts
+Copyright (c) 2022 Saentari
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # dart_lnurl
-[![pub package](https://img.shields.io/badge/pub-0.0.1-blueviolet.svg)](https://pub.dev/packages/dart_lnurl)
+[![pub package](https://img.shields.io/badge/pub-0.2.1-blueviolet.svg)](https://pub.dev/packages/dart_lnurl)
 
 A Dart implementation of lnurl to decode bech32 lnurl strings or raw (non bech32-encoded) URLs. Currently supports the following tags:
 * withdrawRequest
@@ -14,7 +14,7 @@ A Dart implementation of lnurl to decode bech32 lnurl strings or raw (non bech32
 * ✅ LinkingKey derivation for BIP-32 based wallets.
 
 
-Learn more about the lnurl spec here: https://github.com/btcontract/lnurl-rfc
+Learn more about the lnurl spec here: https://github.com/fiatjaf/lnurl-rfc
 
 # API Reference
 
@@ -24,3 +24,27 @@ Use this to parse an encoded bech32 lnurl string or raw (non bech32-encoded) URL
 `String decryptSuccessActionAesPayload({LNURLPaySuccessAction successAction, String preimage})`
 
 When doing lnurl pay, the success action could contain an encrypted payload using the payment preimage. Use this function to decrypt that payload.
+
+## Supported LUDs
+🟢 fully supported, 🟠 partially supported, 🔴 not supported.
+
+* 🟠 [LUD-01: Base LNURL encoding and decoding](https://github.com/fiatjaf/lnurl-rfc/blob/luds/01.md)
+* 🟢 [LUD-02: channelRequest base spec](https://github.com/fiatjaf/lnurl-rfc/blob/luds/02.md)
+* 🟢 [LUD-03: withdrawRequest base spec](https://github.com/fiatjaf/lnurl-rfc/blob/luds/03.md)
+* 🟢 [LUD-04: auth base spec](https://github.com/fiatjaf/lnurl-rfc/blob/luds/04.md)
+* 🟢 [LUD-05: BIP32-based seed generation for auth protocol](https://github.com/fiatjaf/lnurl-rfc/blob/luds/05.md)
+* 🟢 [LUD-06: payRequest base spec](https://github.com/fiatjaf/lnurl-rfc/blob/luds/06.md)
+* 🔴 [LUD-07: hostedChannelRequest base spec](https://github.com/fiatjaf/lnurl-rfc/blob/luds/07.md)
+* 🔴 [LUD-08: Fast withdrawRequest](https://github.com/fiatjaf/lnurl-rfc/blob/luds/08.md)
+* 🟢 [LUD-09: successAction field for payRequest](https://github.com/fiatjaf/lnurl-rfc/blob/luds/09.md)
+* 🟢 [LUD-10: aes success action in payRequest](https://github.com/fiatjaf/lnurl-rfc/blob/luds/10.md)
+* 🟢 [LUD-11: Disposable and storeable payRequests](https://github.com/fiatjaf/lnurl-rfc/blob/luds/11.md)
+* 🟢 [LUD-12: Comments in payRequest](https://github.com/fiatjaf/lnurl-rfc/blob/luds/12.md)
+* 🔴 [LUD-13: signMessage-based seed generation for auth protocol](https://github.com/fiatjaf/lnurl-rfc/blob/luds/13.md)
+* 🟢 [LUD-14: balanceCheck: reusable withdrawRequests](https://github.com/fiatjaf/lnurl-rfc/blob/luds/14.md)
+* 🔴 [LUD-15: balanceNotify: services hurrying up the withdraw process](https://github.com/fiatjaf/lnurl-rfc/blob/luds/15.md)
+* 🔴 [LUD-16: Paying to static internet identifiers](https://github.com/fiatjaf/lnurl-rfc/blob/luds/16.md)
+* 🟢 [LUD-17: Protocol schemes and raw (non bech32-encoded) URLs](https://github.com/fiatjaf/lnurl-rfc/blob/luds/17.md)
+* 🟢 [LUD-18: Payer identity in payRequest protocol](https://github.com/fiatjaf/lnurl-rfc/blob/luds/18.md)
+* 🟢 [LUD-19: Pay link discoverable from withdraw link](https://github.com/fiatjaf/lnurl-rfc/blob/luds/19.md)
+* 🔴 [LUD-20: Long payment description for pay protocol](https://github.com/fiatjaf/lnurl-rfc/blob/luds/20.md)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Dart implementation of lnurl to decode bech32 lnurl strings or raw (non bech32
 * ✅ Decode a bech32-encoded lnurl string.
 * ✅ Handle LUD-17: Protocol schemes and raw (non bech32-encoded) URLs.
 * ✅ Make GET request to the decoded ln service and return the response.
+* ✅ LinkingKey derivation for BIP-32 based wallets.
 
 
 Learn more about the lnurl spec here: https://github.com/btcontract/lnurl-rfc

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -24,14 +24,7 @@ Future<LNURLParseResult> getParams(String encodedUrl) async {
   /// Try to parse the input as a lnUrl. Will throw an error if it fails.
   final lnUrl = findLnUrl(encodedUrl);
 
-  late final Uri decodedUri;
-  if (lnUrl.startsWith('http')) {
-    decodedUri = Uri.parse(lnUrl);
-  } else {
-    /// Decode the lnurl using bech32
-    final bech32 = Bech32Codec().decode(lnUrl, lnUrl.length);
-    decodedUri = Uri.parse(utf8.decode(fromWords(bech32.data)));
-  }
+  final Uri decodedUri = decodeLnUri(encodedUrl);
 
   try {
     Map<String, dynamic> uriParams = {};
@@ -114,6 +107,20 @@ Future<LNURLParseResult> getParams(String encodedUrl) async {
       }),
     );
   }
+}
+
+Uri decodeLnUri(String encodedUrl) {
+  final lnUrl = findLnUrl(encodedUrl);
+
+  late final Uri decodedUri;
+  if (lnUrl.startsWith('http')) {
+    decodedUri = Uri.parse(lnUrl);
+  } else {
+    /// Decode the lnurl using bech32
+    final bech32 = Bech32Codec().decode(lnUrl, lnUrl.length);
+    decodedUri = Uri.parse(utf8.decode(fromWords(bech32.data)));
+  }
+  return decodedUri;
 }
 
 bool validateLnUrl(encodedUrl) {

--- a/lib/dart_lnurl.dart
+++ b/lib/dart_lnurl.dart
@@ -115,3 +115,12 @@ Future<LNURLParseResult> getParams(String encodedUrl) async {
     );
   }
 }
+
+bool validateLnUrl(encodedUrl) {
+  try {
+    findLnUrl(encodedUrl);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}

--- a/lib/src/lnurl.dart
+++ b/lib/src/lnurl.dart
@@ -13,7 +13,11 @@ String findLnUrl(String input) {
     if (Uri.tryParse(input)?.hasAbsolutePath ?? false) {
       // Replace prefix with https for clearnet URL's, http for onion URLs
       var prefix = RegExp(r'\.onion($|\W)').hasMatch(input) ? 'http' : 'https';
-      return input.replaceFirst(lud17schemePrefix, prefix);
+      if (input.contains(lud17schemePrefix)) {
+        return input.replaceFirst(lud17schemePrefix, prefix);
+      } else if (input.startsWith('keyauth://')) {
+        return input.replaceFirst('keyauth', prefix);
+      }
     }
   }
   throw ArgumentError('Not a valid lnurl string');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   bech32:
     dependency: "direct main"
     description:
@@ -29,6 +29,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.1"
+  bip32:
+    dependency: "direct main"
+    description:
+      name: bip32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -36,13 +43,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  bs58check:
+    dependency: transitive
+    description:
+      name: bs58check
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -56,7 +70,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -78,6 +92,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  ecdsa:
+    dependency: "direct main"
+    description:
+      name: ecdsa
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
+  elliptic:
+    dependency: transitive
+    description:
+      name: elliptic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.8"
   encrypt:
     dependency: "direct main"
     description:
@@ -91,7 +119,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -102,6 +130,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  hex:
+    dependency: transitive
+    description:
+      name: hex
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   http:
     dependency: "direct main"
     description:
@@ -129,28 +164,35 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
+  ninja_asn1:
+    dependency: transitive
+    description:
+      name: ninja_asn1
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   pointycastle:
     dependency: transitive
     description:
@@ -169,7 +211,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -190,21 +232,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_lnurl
-description: A Dart implementation of lnurl to decode bech32 lnurl strings.
-version: 0.2.0
+description: A Dart implementation of the LNURL specification.
+version: 0.2.1
 homepage: https://github.com/saentari/dart_lnurl
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_lnurl
 description: A Dart implementation of lnurl to decode bech32 lnurl strings.
-version: 0.1.0
-homepage: https://github.com/bottlepay/dart_lnurl
+version: 0.2.0
+homepage: https://github.com/saentari/dart_lnurl
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -9,8 +9,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  encrypt: ^5.0.1
   bech32: ^0.2.1
+  bip32: ^2.0.0
+  ecdsa: ^0.0.4
+  encrypt: ^5.0.1
   http: ^0.13.4
 
 dev_dependencies:

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -1,111 +1,305 @@
+import 'dart:convert';
+
 import 'package:bip32/bip32.dart' as bip32;
 import 'package:dart_lnurl/dart_lnurl.dart';
 import 'package:dart_lnurl/src/lnurl.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hex/hex.dart';
+import 'package:http/http.dart';
 
 import 'util.dart';
 
 void main() {
-  test('should match as valid lnurl', () {
-    final lnurl =
-        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
-    expect(validateLnUrl(lnurl), true);
-  });
+  group('LUD-01: Base LNURL encoding and decoding', () {
+    const encodedLnurl =
+        'lnurl1dp68gurn8ghj7mrww4exctnxd9shg6npvchxxmmd9akxuatjdskhqcte8aek2umnd9hku0fjx43nvdm9vsekxdnr8qenzdrxxccnsv33vfjkvefkxuuxgwrzxucnzefnvy6nwd3cvfnrqep4893rqvfk8psngd358y6rxd3evccxx94zkxx';
+    const decodedLnurl =
+        'https://lnurl.fiatjaf.com/lnurl-pay?session=25c67ed3c6c8314f61821befe678d8b711e3a5768bf0d59b0168a46494369f0c';
 
-  test('should match as invalid lnurl', () {
-    final lnurl = 'InvalidLightningUrlString';
-    expect(validateLnUrl(lnurl), false);
-  });
+    test('base LNURL decoding', () {
+      final res = decodeLnUri(encodedLnurl);
 
-  test('should match lnurl without lightning:', () {
-    final lnurl =
-        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
-    expect(findLnUrl(lnurl),
-        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq');
-  });
-
-  test('should match lnurl with lightning:', () {
-    final lnurl =
-        'lightning:lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
-    expect(findLnUrl(lnurl),
-        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq');
-  });
-
-  test('should fail matching lnurl on invalid string', () {
-    expect(() => findLnUrl('invalid string'), throwsArgumentError);
-  });
-
-  test('should decipher preimage', () {
-    final plainText = 'Secret message here';
-    final preimage =
-        '43aa9346163deada83ec49fa670b8a3541c9ef469d942cd2c7f81206e535e031';
-
-    /// Encrypt some data using the preimage as the key
-    final data = encrypt(plainText, preimage);
-
-    LNURLPaySuccessAction successAction = LNURLPaySuccessAction.fromJson({
-      'description': 'Secret message',
-      'tag': 'aes',
-      'cipherText': data.cipherText,
-      'iv': data.iv,
+      expect(res.toString(), decodedLnurl);
     });
-    if (validateSuccessAction(successAction: successAction)) {
-      final decrypted = decryptSuccessActionAesPayload(
-        preimage: preimage,
-        successAction: successAction,
-      );
-      expect(decrypted, plainText);
-    }
+
+    test('base LNURL encoding', () {
+      // TODO: missing implementation.
+    });
   });
 
-  test('should decode lnurl-pay', () async {
-    final url =
-        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
-    final uri = decodeLnUri(url);
-    final res = await getParams(url);
+  group('LUD-02: channelRequest base spec', () {
+    test('should decode lnurl-channel', () async {
+      const url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKKX6RPDEHX2MPLWDJHXUMFDAHR6VF4V5MNXENP8Y6NXEPSXV6XGD33XGUNQWT9XYENGWRYX3JNYCEJXU6XGDFSVYCXXWTXX5CRZDM9V33NWVFCXCMRVVEJX5MRQV3K8Y6QSN500R';
+      final res = await getParams(url);
 
-    expect(uri.host, 'lnurl.fiatjaf.com');
-    expect(res.payParams, isNotNull);
+      expect(res.channelParams?.tag, 'channelRequest');
+      expect(res.channelParams?.callback, isNotEmpty);
+    });
   });
 
-  test('should find lnurl-auth params', () async {
-    final url =
-        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKKCMM8D9HR7ARPVU7KCMM8D9HZV6E384JNXCF3VSCNSE358QMKZVPK8YENZVMYXUEN2DE4X5CNGWP4VSMX2VE58Q6KYCFNX5UXVDNXX9JKXDENVDSNSCE5XU6XVVR9V56XGCTZS8GQ23';
-    final res = await getParams(url);
-    expect(res.authParams, isNotNull);
-    expect(res.error, isNull);
+  group('LUD-03: withdrawRequest base spec', () {
+    test('should decode lnurl-withdraw', () async {
+      const url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHW6T5DPJ8YCTH8AEK2UMND9HKU0TPV4NRGCN9XA3NQWRP8YMKXVTPVCCXGWTZ8YER2WTPVYMRGWFSVS6RYEPKVVMNJETYVGEXYVPJXFNRZCMZXAJN2CENXVENGEFNV9SNX09GNJU';
+      final res = await getParams(url);
+
+      expect(res.withdrawalParams?.tag, 'withdrawRequest');
+      expect(res.withdrawalParams?.maxWithdrawable, greaterThan(0));
+      expect(res.withdrawalParams, isNotNull);
+      expect(res.error, isNull);
+    });
   });
 
-  test('should create linkingKey derivation for BIP-32 based wallet', () async {
+  group('LUD-04: auth base spec', () {
+    test('should find lnurl-auth params', () async {
+      const url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKKCMM8D9HR7ARPVU7KCMM8D9HZV6E384JNXCF3VSCNSE358QMKZVPK8YENZVMYXUEN2DE4X5CNGWP4VSMX2VE58Q6KYCFNX5UXVDNXX9JKXDENVDSNSCE5XU6XVVR9V56XGCTZS8GQ23';
+      final res = await getParams(url);
+
+      expect(res.authParams?.tag, 'login');
+      expect(res.authParams, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-05: BIP32-based seed generation for auth protocol', () {
     const url =
         'lightning:LNURL1DP68GURN8GHJ7MRFVA58GMNFDENKCMM8D9HZUMRFWEJJ7MR0VA5KU0MTXY7NWCNYXSMKVCEKX3JRSCF4X3SKXWTXXASNGVE5XQ6RZDMXXC6KXDE3VYCRZCENXF3NQVF5XCEXZE3JXVMRGVRY8YURJVNYV43RGDRRVGN8GCT884KX7EMFDCV8DETA';
     final masterKey = bip32.BIP32.fromBase58(
         'xprv9s21ZrQH143K4DRBUU8Dp25M61mtjm9T3LsdLLFCXL2U6AiKEqs7dtCJWGFcDJ9DtHpdwwmoqLgzPrW7unpwUyL49FZvut9xUzpNB6wbEnz');
-    const linkingPubKeyHex =
-        '034c9c690b5f8e07517bcf16fda57c8fb363ad5edab66fccaa1cbf2287d186fa83';
-    final linkingKey = await deriveLinkingKey(url, masterKey);
-    final derivedPubKeyHex = HEX.encode(linkingKey.publicKey);
 
-    /// linkingPubKeyHex is send as an identifier (key) to servers
-    expect(derivedPubKeyHex, linkingPubKeyHex);
+    test('should create linkingKey derivation for BIP-32 based wallet',
+        () async {
+      const linkingPubKeyHex =
+          '034c9c690b5f8e07517bcf16fda57c8fb363ad5edab66fccaa1cbf2287d186fa83';
+      final linkingKey = await deriveLinkingKey(url, masterKey);
+      final derivedPubKeyHex = HEX.encode(linkingKey.publicKey);
+
+      expect(derivedPubKeyHex, linkingPubKeyHex);
+    });
+
+    test('should create signature from signed k1 with linkingKey', () async {
+      const expectedSig =
+          '304402203b6f6fb1c0ae2fcac3b5cce2d528f040f26622470c8bb7ada3fa8c158b4b7c0a02207296db00fdb38f839eae197d90bfca79aa2cbe0d081025f8277fe10e5017bd20';
+      const callBackUrl =
+          'https://lightninglogin.live/login?k1=7bd47fc64d8a54ac9f7a4340417f65c71a01c32c01462af23640d9892deb44cb&tag=login&sig=304402203b6f6fb1c0ae2fcac3b5cce2d528f040f26622470c8bb7ada3fa8c158b4b7c0a02207296db00fdb38f839eae197d90bfca79aa2cbe0d081025f8277fe10e5017bd20&key=034c9c690b5f8e07517bcf16fda57c8fb363ad5edab66fccaa1cbf2287d186fa83';
+      final linkingKey = await deriveLinkingKey(url, masterKey);
+      final key = HEX.encode(linkingKey.publicKey);
+      final sig = await signK1(url, linkingKey);
+      final decodedUrl = decodeLnUri(url);
+      final callback = '$decodedUrl&sig=${sig}&key=${key}';
+
+      expect(sig, expectedSig);
+      expect(callback, callBackUrl);
+    });
   });
 
-  test('should create signature from signed k1 with linkingKey', () async {
-    const url =
-        'lightning:LNURL1DP68GURN8GHJ7MRFVA58GMNFDENKCMM8D9HZUMRFWEJJ7MR0VA5KU0MTXY7NWCNYXSMKVCEKX3JRSCF4X3SKXWTXXASNGVE5XQ6RZDMXXC6KXDE3VYCRZCENXF3NQVF5XCEXZE3JXVMRGVRY8YURJVNYV43RGDRRVGN8GCT884KX7EMFDCV8DETA';
-    final masterKey = bip32.BIP32.fromBase58(
-        'xprv9s21ZrQH143K4DRBUU8Dp25M61mtjm9T3LsdLLFCXL2U6AiKEqs7dtCJWGFcDJ9DtHpdwwmoqLgzPrW7unpwUyL49FZvut9xUzpNB6wbEnz');
-    const expectedSig =
-        '304402203b6f6fb1c0ae2fcac3b5cce2d528f040f26622470c8bb7ada3fa8c158b4b7c0a02207296db00fdb38f839eae197d90bfca79aa2cbe0d081025f8277fe10e5017bd20';
-    const callBackUrl =
-        'https://lightninglogin.live/login?k1=7bd47fc64d8a54ac9f7a4340417f65c71a01c32c01462af23640d9892deb44cb&tag=login&sig=304402203b6f6fb1c0ae2fcac3b5cce2d528f040f26622470c8bb7ada3fa8c158b4b7c0a02207296db00fdb38f839eae197d90bfca79aa2cbe0d081025f8277fe10e5017bd20&key=034c9c690b5f8e07517bcf16fda57c8fb363ad5edab66fccaa1cbf2287d186fa83';
-    final linkingKey = await deriveLinkingKey(url, masterKey);
-    final key = HEX.encode(linkingKey.publicKey);
-    final sig = await signK1(url, linkingKey);
-    final decodedUrl = decodeLnUri(url);
-    final callback = '$decodedUrl&sig=${sig}&key=${key}';
-    expect(sig, expectedSig);
-    expect(callback, callBackUrl);
+  group('LUD-06: payRequest base spec', () {
+    test('should decode lnurl-pay', () async {
+      final url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
+      final res = await getParams(url);
+
+      expect(res.payParams?.minSendable, greaterThan(0));
+      expect(res.payParams?.metadata, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-07: hostedChannelRequest base spec', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('LUD-08: Fast withdrawRequest', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('LUD-09: successAction field for payRequest', () {
+    test('should create and validate successAction', () {
+      final plainText = 'Secret message here';
+      final preimage =
+          '43aa9346163deada83ec49fa670b8a3541c9ef469d942cd2c7f81206e535e031';
+      // Encrypt some data using the preimage as the key
+      final data = encrypt(plainText, preimage);
+
+      LNURLPaySuccessAction successAction = LNURLPaySuccessAction.fromJson({
+        'description': 'Secret message',
+        'tag': 'aes',
+        'cipherText': data.cipherText,
+        'iv': data.iv,
+      });
+      if (validateSuccessAction(successAction: successAction)) {
+        final decrypted = decryptSuccessActionAesPayload(
+          preimage: preimage,
+          successAction: successAction,
+        );
+        expect(decrypted, plainText);
+      }
+    });
+  });
+
+  group('LUD-10: aes success action in payRequest', () {
+    test('should create and validate aes successAction', () {
+      // The test for for LUD-10 is included in LUD-09
+    });
+  });
+
+  group('LUD-11: Disposable and storeable payRequests', () {
+    test('should include disposable field in LNURL-pay callback', () {
+      LNURLPayResult payResult = LNURLPayResult.fromJson(
+          {'pr': 'payRequest string', 'routes': [], 'disposable': true});
+
+      expect(payResult.disposable, true);
+    });
+  });
+
+  group('LUD-12: Comments in payRequest', () {
+    test('should support commentAllowed tag', () async {
+      final url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
+      final res = await getParams(url);
+
+      expect(res.payParams?.commentAllowed, greaterThanOrEqualTo(0));
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-13: signMessage-based seed generation for auth protocol', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('LUD-14: balanceCheck: reusable withdrawRequests', () {
+    test('should support balanceCheck in withdrawRequests', () async {
+      const url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHW6T5DPJ8YCTH8AEK2UMND9HKU0TPV4NRGCN9XA3NQWRP8YMKXVTPVCCXGWTZ8YER2WTPVYMRGWFSVS6RYEPKVVMNJETYVGEXYVPJXFNRZCMZXAJN2CENXVENGEFNV9SNX09GNJU';
+      final res = await getParams(url);
+      // Workaround for optional currentBalance field not being present
+      final maxWithdrawableBefore = res.withdrawalParams?.maxWithdrawable;
+      final balanceCheckUrl = res.withdrawalParams?.balanceCheck;
+      final callback = await get(Uri.parse(balanceCheckUrl!));
+      final resBody = jsonDecode(callback.body);
+      final maxWithdrawableAfter = resBody['maxWithdrawable'];
+
+      expect(res.withdrawalParams?.balanceCheck, isNotEmpty);
+      // maxWithdrawableAfter should be less than maxWithdrawableBefore, but test service uses random numbers.
+      expect(true, maxWithdrawableBefore != maxWithdrawableAfter);
+      expect(res.withdrawalParams, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-15: balanceNotify: services hurrying up the withdraw process', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('LUD-16: Paying to static internet identifiers', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('LUD-17: Protocol schemes and raw (non bech32-encoded) URLs', () {
+    test('should support lnurlc scheme', () async {
+      final lnurlc =
+          'lnurlc://lnurl.fiatjaf.com/lnurl-channel?session=fe89283f63dd5514902c41b2c5e98b3cc529c0af985212bc0921726be18d4bcd';
+      final res = await getParams(lnurlc);
+
+      expect(res.channelParams, isNotNull);
+      expect(res.error, isNull);
+    });
+    test('should support lnurlw scheme', () async {
+      final lnurlw =
+          'lnurlw://lnurl.fiatjaf.com/lnurl-withdraw?session=df9c930b4ae3c879517e436d6f04e6b09aa9f8364f1e02a55d8feb73594b5189';
+      final res = await getParams(lnurlw);
+
+      expect(res.withdrawalParams, isNotNull);
+      expect(res.error, isNull);
+    });
+    test('should support lnurlp scheme', () async {
+      final lnurlp =
+          'lnurlp://lnurl.fiatjaf.com/lnurl-pay?session=4d2636d9ae7d9db55e1ed21c5da514a8dee29f37fcf844a3a3a9ea89faff7cc0';
+      final res = await getParams(lnurlp);
+
+      expect(res.payParams, isNotNull);
+      expect(res.error, isNull);
+    });
+    test('should support keyauth scheme', () async {
+      final keyauth =
+          'keyauth://lnurl.fiatjaf.com/lnurl-login?tag=login&k1=db667ee286556bebe60796ab4c7ea48393fa647054c40c67750c663ab1705c30';
+      final res = await getParams(keyauth);
+
+      expect(res.authParams, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-18: Payer identity in payRequest protocol', () {
+    test('should identify if SERVICE requires payer identities', () async {
+      final url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
+      final res = await getParams(url);
+
+      expect(res.payParams?.payerData?.name?.mandatory, false);
+      expect(res.payParams?.payerData?.email?.mandatory, false);
+      expect(res.payParams?.payerData, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-19: Pay link discoverable from withdraw link', () {
+    test('should include a payLink', () async {
+      const url =
+          'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHW6T5DPJ8YCTH8AEK2UMND9HKU0TPV4NRGCN9XA3NQWRP8YMKXVTPVCCXGWTZ8YER2WTPVYMRGWFSVS6RYEPKVVMNJETYVGEXYVPJXFNRZCMZXAJN2CENXVENGEFNV9SNX09GNJU';
+      final res = await getParams(url);
+
+      expect(res.withdrawalParams?.payLink, isNotNull);
+      expect(res.error, isNull);
+    });
+  });
+
+  group('LUD-20: Long payment description for pay protocol', () {
+    test('placeholder', () {
+      // TODO: missing implementation.
+    });
+  });
+
+  group('Miscellaneous: Validate LNURL', () {
+    test('should match as valid lnurl', () {
+      final lnurl =
+          'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+      expect(validateLnUrl(lnurl), true);
+    });
+
+    test('should match as invalid lnurl', () {
+      final lnurl = 'InvalidLightningUrlString';
+      expect(validateLnUrl(lnurl), false);
+    });
+
+    test('should match lnurl without lightning:', () {
+      final lnurl =
+          'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+      expect(findLnUrl(lnurl),
+          'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq');
+    });
+
+    test('should match lnurl with lightning:', () {
+      final lnurl =
+          'lightning:lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+      expect(findLnUrl(lnurl),
+          'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq');
+    });
+
+    test('should fail matching lnurl on invalid string', () {
+      expect(() => findLnUrl('invalid string'), throwsArgumentError);
+    });
   });
 }

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -39,7 +39,7 @@ void main() {
       'cipherText': data.cipherText,
       'iv': data.iv,
     });
-    if(validateSuccessAction(successAction: successAction)){
+    if (validateSuccessAction(successAction: successAction)) {
       final decrypted = decryptSuccessActionAesPayload(
         preimage: preimage,
         successAction: successAction,
@@ -49,8 +49,17 @@ void main() {
   });
 
   test('should decode lnurl-pay', () async {
-    final url = 'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
+    final url =
+        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
     final res = await getParams(url);
     expect(res.payParams, isNotNull);
+  });
+
+  test('should find lnurl-auth params', () async {
+    final url =
+        'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKKCMM8D9HR7ARPVU7KCMM8D9HZV6E384JNXCF3VSCNSE358QMKZVPK8YENZVMYXUEN2DE4X5CNGWP4VSMX2VE58Q6KYCFNX5UXVDNXX9JKXDENVDSNSCE5XU6XVVR9V56XGCTZS8GQ23';
+    final res = await getParams(url);
+    expect(res.authParams, isNotNull);
+    expect(res.error, isNull);
   });
 }

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -1,11 +1,21 @@
 import 'package:dart_lnurl/dart_lnurl.dart';
 import 'package:dart_lnurl/src/lnurl.dart';
-import 'package:dart_lnurl/src/types.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'util.dart';
 
 void main() {
+  test('should match as valid lnurl', () {
+    final lnurl =
+        'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';
+    expect(validateLnUrl(lnurl), true);
+  });
+
+  test('should match as invalid lnurl', () {
+    final lnurl = 'InvalidLightningUrlString';
+    expect(validateLnUrl(lnurl), false);
+  });
+
   test('should match lnurl without lightning:', () {
     final lnurl =
         'lnurl1dp68gurn8ghj7mrww4exctt5dahkccn00qhxget8wfjk2um0veax2un09e3k7mf0w5lhz0t9xcekzv34vgcx2vfkvcurxwphvgcrwefjvgcnqwrpxqmkxven89skgvp3vs6nwvpjvy6njdfsx5ekgephvcurxdf5xcerwvecvyunsf32lqq';

--- a/test/dart_lnurl_test.dart
+++ b/test/dart_lnurl_test.dart
@@ -36,7 +36,6 @@ void main() {
 
   test('should decipher preimage', () {
     final plainText = 'Secret message here';
-
     final preimage =
         '43aa9346163deada83ec49fa670b8a3541c9ef469d942cd2c7f81206e535e031';
 
@@ -61,7 +60,10 @@ void main() {
   test('should decode lnurl-pay', () async {
     final url =
         'lightning:LNURL1DP68GURN8GHJ7MRWW4EXCTNXD9SHG6NPVCHXXMMD9AKXUATJDSKHQCTE8AEK2UMND9HKU0F3VFNRVVF5XU6XGD33X9JNJD3SVSMKZVMRX4NX2VPSVCMNWDP4XVUXVEPHVVURJCFCXUUNWDEE8YCNYWTRXQ6NSWP4V56RJEFKVCCXYXKMWAE';
+    final uri = decodeLnUri(url);
     final res = await getParams(url);
+
+    expect(uri.host, 'lnurl.fiatjaf.com');
     expect(res.payParams, isNotNull);
   });
 


### PR DESCRIPTION
According to the [LUD-04: `auth` base spec.](https://github.com/fiatjaf/lnurl-rfc/blob/luds/04.md) "**Wallet to service interaction flow**", no GET should be made yet when the `tag` with value is set to `login`. Instead all parameters are retrieved from the `LNURL`.

Currently, the `LNURL-auth` service interaction flow breaks, and properties are placed within the `LNURLErrorResponse`, and not in the `LNURLAuthParams`.

The solution I propose is to check if the decodedUri contains `tag=login`. If it does, then the lnurl matches with `LNURL-auth`, if not then the service interaction flow can continue as normal for `LNURL-pay`, `LNURL-withdraw`, or `LNURL-channel`.
